### PR TITLE
Adds data method

### DIFF
--- a/src/WebPushMessage.php
+++ b/src/WebPushMessage.php
@@ -37,6 +37,13 @@ class WebPushMessage
      *
      * @var array
      */
+    protected $data = [];
+
+    /**
+     * The notification actions.
+     *
+     * @var array
+     */
     protected $actions = [];
 
     /**
@@ -112,6 +119,19 @@ class WebPushMessage
     }
 
     /**
+     * Set the data.
+     *
+     * @param  arr $data
+     * @return $this
+     */
+    public function data($data)
+    {
+        $this->data = $data;
+
+        return $this;
+    }
+
+    /**
      * Set an action.
      *
      * @param  string $title
@@ -136,6 +156,7 @@ class WebPushMessage
             'id' => $this->id,
             'title' => $this->title,
             'body' => $this->body,
+            'data' => $this->data,
             'actions' => $this->actions,
             'icon' => $this->icon,
         ];

--- a/tests/ChannelTest.php
+++ b/tests/ChannelTest.php
@@ -81,6 +81,6 @@ class ChannelTest extends TestCase
      */
     protected function getPayload()
     {
-        return '{"id":1,"title":"Title","body":"Body","actions":[{"title":"Title","action":"Action"}],"icon":"Icon"}';
+        return '{"id":1,"title":"Title","body":"Body","data":{"foo":"bar"},"actions":[{"title":"Title","action":"Action"}],"icon":"Icon"}';
     }
 }

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -71,4 +71,12 @@ class MessageTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(1, $this->message->toArray()['id']);
     }
+
+    /** @test */
+    public function it_can_set_the_data()
+    {
+        $this->message->data(['foo', 'bar']);
+
+        $this->assertEquals([['foo', 'bar']], $this->message->toArray()['data']);
+    }
 }

--- a/tests/TestNotification.php
+++ b/tests/TestNotification.php
@@ -21,6 +21,7 @@ class TestNotification extends Notification
             ->title('Title')
             ->icon('Icon')
             ->body('Body')
+            ->data(['foo' => 'bar'])
             ->action('Title', 'Action');
     }
 }


### PR DESCRIPTION
Adds a data() method to WebPushMessage

Currently, Chrome support this attribute to be sent with the notification. Useful for adding additional data to the notification.